### PR TITLE
scenario specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 /config/master.key
 
 .env.development
+/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@prettier/plugin-ruby": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-ruby/-/plugin-ruby-0.12.3.tgz",
+      "integrity": "sha512-2DEsy9L5MW6fPCIHtl5b2ghVSh+J3ZBm+eyXDX8e/crKxVxzSdqMcYAHFdgtaZHMZvXvrFsftCZjw5qkwm3p3A==",
+      "dev": true,
+      "requires": {
+        "prettier": "^1.16.4"
+      }
+    },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@prettier/plugin-ruby": "^0.12.3",
+    "prettier": "^1.18.2"
+  }
+}

--- a/spec/config/graphql.rb
+++ b/spec/config/graphql.rb
@@ -1,0 +1,41 @@
+# NOTE: based on <https://github.com/leihs/leihs-procure/blob/6b51ac57c1d7764831c8fad94d05f84b0bf7882e/server/spec/graphql/graphql_helper.rb>
+#       but adapted to use request-type rails spec helpers
+
+class GraphqlQuery
+  URL = '/graphql'
+  HTTP_CLIENT = ActionDispatch::Integration::Session
+
+  attr_reader :response
+
+  def initialize(document, variables = {})
+    @document = document.to_s
+    @variables = variables.as_json
+    @http_client = HTTP_CLIENT.new(Rails.application)
+  end
+
+  def perform
+    options = {
+      headers: {
+        'Accept': 'application/json', 'Content-Type': 'application/json'
+      },
+      params: { query: @document, variables: @variables }.to_json
+    }
+
+    @http_client.post(URL, options)
+    @response = @http_client.instance_variable_get('@response')
+    self
+  end
+
+  def result
+    JSON.parse(@response.body).deep_symbolize_keys
+  end
+end
+
+# RSpec.shared_context 'graphql client' do
+
+def graphql_request(document, variables = {})
+  GraphqlQuery.new(document, variables).perform
+end
+# end
+
+# RSpec.configure { |config| config.include_context 'graphql client' }

--- a/spec/scenarios/basic_spec.rb
+++ b/spec/scenarios/basic_spec.rb
@@ -1,0 +1,70 @@
+describe 'Request-based GraphQL integration tests', type: :request do
+  example 'basic introspection works' do
+    doc = <<-GRAPHQL
+      query { __schema { queryType { name } } }
+    GRAPHQL
+
+    result = graphql_request(doc).result
+
+    expect(result[:errors]).not_to be_present
+
+    expect(result).to eq(
+      { data: { __schema: { queryType: { name: 'Query' } } } }
+    )
+  end
+
+  context 'correct error handling' do
+    example 'invalid document' do
+      expect(graphql_request('INVALID_DOCUMENT').result).to eq(
+        {
+          errors: [
+            {
+              locations: [{ column: 1, line: 1 }],
+              message:
+                'Parse error on "INVALID_DOCUMENT" (IDENTIFIER) at [1, 1]'
+            }
+          ]
+        }
+      )
+    end
+
+    context 'variables' do
+      let(:doc) do
+        <<-GRAPHQL
+        query typeByName($myTypeName: String!) { __type(name: $myTypeName) { name } }
+      GRAPHQL
+      end
+
+      it 'works' do
+        vars = { myTypeName: 'Query' }
+        expect(graphql_request(doc, vars).result).to eq(
+          { data: { __type: { name: 'Query' } } }
+        )
+      end
+
+      example 'error for missing variable' do
+        result = graphql_request(doc, {}).result
+        expect(result[:errors].count).to be 1
+        expect(result[:errors].first.slice(:locations, :message)).to eq(
+          {
+            locations: [{ column: 26, line: 1 }],
+            message:
+              'Variable myTypeName of type String! was provided invalid value'
+          }
+        )
+      end
+
+      example 'error for wrong variable type' do
+        result = graphql_request(doc, { myTypeName: 1_234 }).result
+        expect(result[:errors].count).to be 1
+        expect(result[:errors].first.slice(:locations, :message)).to eq(
+          {
+            locations: [{ column: 26, line: 1 }],
+            message:
+              'Variable myTypeName of type String! was provided invalid value'
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/scenarios/entry_meta_data_spec.rb
+++ b/spec/scenarios/entry_meta_data_spec.rb
@@ -1,0 +1,24 @@
+#
+#  WORK
+#  IN
+#  PROGRESS
+#
+
+describe 'MediaEntry Metadata', type: :request do
+  let(:the_entry) { entry = FactoryGirl.create(:media_entry) }
+
+  example 'query all' do
+    vars = { entryId: the_entry.id }
+    doc = <<-GRAPHQL
+      query oneMediaEntryWithAllMetaData($entryId: ID!) {
+        mediaEntry(id: $entryId) {
+          id
+        }
+      }
+    GRAPHQL
+
+    expect(graphql_request(doc, vars).result).to eq(
+      { data: { mediaEntry: { id: the_entry.id } } }
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,4 +4,4 @@ require 'pry'
 require 'config/rspec'
 require 'config/rails'
 require 'config/database'
-
+require 'config/graphql'


### PR DESCRIPTION
@kooropatfa FYI this adds a `graphql_request` helper that works with `rspec-rails` specs of type "request". Its like a real HTTP request, but more efficient because we re-use the rails stuff (and dont need to start a real server etc).